### PR TITLE
slf4j版本问题，启动报错

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
         <java.version>1.8</java.version>
         <spring.version>4.3.2.RELEASE</spring.version>
         <jackson.version>2.5.0</jackson.version>
-        <slf4j.version>1.7.7</slf4j.version>
+        <slf4j.version>1.7.22</slf4j.version>
         <log4j2.version>2.5</log4j2.version>
         <jooq.version>3.7.3</jooq.version>
         <vertx.version>3.4.2</vertx.version>

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
         <java.version>1.8</java.version>
         <spring.version>4.3.2.RELEASE</spring.version>
         <jackson.version>2.5.0</jackson.version>
-        <slf4j.version>1.7.22</slf4j.version>
+        <slf4j.version>1.7.23</slf4j.version>
         <log4j2.version>2.5</log4j2.version>
         <jooq.version>3.7.3</jooq.version>
         <vertx.version>3.4.2</vertx.version>


### PR DESCRIPTION
严重: Failed to deploy verticle com.mpush.mpns.web.AppServer
java.lang.NoClassDefFoundError: org/slf4j/LoggerFactory
	at com.mpush.mpns.web.AppServer.<init>(AppServer.java:34)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
	at java.lang.Class.newInstance(Class.java:442)